### PR TITLE
Simplify remove_common_words and clean up input file

### DIFF
--- a/Kanye West College Dropout Full.txt
+++ b/Kanye West College Dropout Full.txt
@@ -41,7 +41,7 @@ Ladies tired of gettin' ripped off by guys like this
 And givin' head is like a whale that's usin' a toothpick
 Well, I'm in the club for a limited time
 Act now and get some action for a $free.99
-Later on I might charge for ménage
+Later on I might charge for menage
 Heard her man was the boss of the floss
 But she still want to toss me the drawers
 And it ain't gon' cost me because she my caddy
@@ -315,7 +315,12 @@ Keep 'em high
 And if you're losin' your high then smoke again
 Keep 'em high
 
-What in the fuck was that Kanye?! I told you to do some shit for the kids! You can give me your muthafuckin' graduation ticket right now! You give me this muthafuckin' robe before you catch some senioritis! You will not walk across that stage, you won’t slide across that stage! A muthafucka can’t pull you across that stage, Kanye! Who told you? See, I told you to do somethin' uplifting! I’m tryin' to get you out here with these white people and this how you're gonna do me! You know what, you's a nigga. And I don’t mean that in no nice way. Had little kids sing about the shit, the jokes on you. You throw your muthafuckin hands in the air, and wave good-bye to every-mothafuckin-body! Cause you gettin' the fuck out of this campus! What the fuck you gon' do now, Kanye?
+What in the fuck was that Kanye?! I told you to do some shit for the kids! You can give me your
+muthafuckin' graduation ticket right now! You give me this muthafuckin' robe before you catch
+some senioritis! You will not walk across that stage, you won't slide across that stage! A
+muthafucka can't pull you across that stage, Kanye! Who told you? See, I told you to do
+somethin' uplifting! I'm tryin' to get you out here with these white people and this how you're
+gonna do me! You know what, you's a nigga. And I don't mean that in no nice way. Had little kids sing about the shit, the jokes on you. You throw your muthafuckin hands in the air, and wave good-bye to every-mothafuckin-body! Cause you gettin' the fuck out of this campus! What the fuck you gon' do now, Kanye?
 
 I'm no longer confused, but don't tell anybody
 I'm about to break the rules, but don't tell anybody
@@ -1242,7 +1247,7 @@ There's too much stuff on my heart right now, man
 I'd gladly risk it all right now
 It's a life-or-death situation, man
 Y'all, y'all don't really understand how I feel right now, man
-It's your boy, Kanye to the…
+It's your boy, Kanye to the
 Chi-Town, what's goin' on?
 
 I drink a Boost for breakfast, an Ensure for dessert
@@ -1271,7 +1276,7 @@ Right down to the wire, even through the fire
 I really apologize for everything right now
 If it's unclear at all, man
 They got my mouth wired shut
-For like… I dunno, the doctor said like six weeks
+For like I dunno, the doctor said like six weeks
 Y'know, he had, I had reconstructive surgery on my jaw
 I looked in the mirror
 And half my jaw was in the back of my mouth, man
@@ -1295,11 +1300,11 @@ You would know how Mase felt
 Thank God I ain't too cool for the safe belt
 I swear to God, driver two wanna sue
 I got a lawyer for the case, to keep what's in my safe safe
-My dawgs couldn't tell if I…
+My dawgs couldn't tell if I
 I looked like Tom Cruise in Vanilla Sky, it was televised
 There's been an accident like GEICO
 They thought I was burnt up like Pepsi did Michael
-I must got a angel, ‘cause look how death missed his ass
+I must got a angel, cause look how death missed his ass
 Unbreakable, what, you thought they'd call me Mr. Glass?
 Look back on my life like the Ghost of Christmas Past
 Toys "R" Us where I used to spend that Christmas cash
@@ -1511,8 +1516,8 @@ Now, tell me that ain't insecurr
 The concept of school seems so securr
 Sophomore, three yurrs, ain't picked a carurr
 She like, "Fuck it, I'll just stay down hurr and do hair."
-‘Cause that's enough money to buy her a few pairs
-Of new Airs, ‘cause her baby daddy don't really care
+Cause that's enough money to buy her a few pairs
+Of new Airs, cause her baby daddy don't really care
 She's so precious with the peer pressure
 Couldn't afford a car, so she named her daughter Alexis
 She had hair so long that it looked like weave
@@ -1563,7 +1568,7 @@ And the white man get paid off of all of that
 But I ain't even gon' act holier than thou
 'Cause fuck it, I went to Jacob with 25 thou
 Before I had a house and I'd do it again
-‘Cause I wanna be on 106 & Park, pushin' a Benz
+Cause I wanna be on 106 & Park, pushin' a Benz
 I want to act ballerific like it's all terrific
 I got a couple past-due bills, I won't get specific
 I got a problem with spendin' before I get it

--- a/Kanye analysis.py
+++ b/Kanye analysis.py
@@ -11,15 +11,10 @@ def open_file(file_name):
     return words 
 
 def remove_common_words(words):
-    running = True 
-    while running:
-        for i in words:
-            if i in common_words:
-                words.remove(i)
-        if any(x in common_words for x in words):
-            pass
-        else:
-            running = False
+    while any(x in common_words for x in words):
+        for w in words:
+            if w in common_words:
+                words.remove(w)
     return words
 
 def words_count(words):  


### PR DESCRIPTION
I removed all the non UTF-8 characters from the text file `Kanye West College Dropout Full.txt` and simplified the loop in `remove_common_words`.  I was going to comment in your earlier code that you were missing an outer loop that was needed so that you didn't skip common words that you already removed in the previous iteration, but looks like you figured that out already.